### PR TITLE
Refactor to sketch out new ideas

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,7 @@
-import React, { Component } from "react";
-import ReactDOM from "react-dom";
-import { withValue } from "react-value";
-import "./index.css";
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { withValue } from 'react-value';
+import './index.css';
 
 const inc = i => (i || 0) + 1;
 
@@ -24,7 +24,7 @@ class Input extends Component {
 
 class InputWithMapping extends Component {
   onClick = () => {
-    this.props.altHandler(inc(this.props.value));
+    this.props.altHandler(inc(this.props.altProp));
   };
   render() {
     return (
@@ -36,9 +36,41 @@ class InputWithMapping extends Component {
   }
 }
 
+class Toggle extends Component {
+  handleToggle = () => {
+    if (this.props.isOpen) {
+      this.props.onClose();
+    } else {
+      this.props.onOpen();
+    }
+  };
+  render() {
+    return (
+      <button onClick={this.handleToggle}>
+        Toggle ({this.props.isOpen ? 'open' : 'closed'})
+      </button>
+    );
+  }
+}
+
 const Example = withValue(Input);
 const ExampleWithMapping = withValue(InputWithMapping, {
-  altProp: "altHandler"
+  altProp: {
+    defaultName: 'defaultAltProp',
+    handlers: {
+      altHandler: v => v,
+    },
+  },
+});
+const ExampleWithMultiProps = withValue(Toggle, {
+  isOpen: {
+    defaultName: 'isOpenByDefault',
+    defaultValue: false,
+    handlers: {
+      onClose: () => false,
+      isOpen: () => true,
+    },
+  },
 });
 
 class App extends Component {
@@ -60,16 +92,25 @@ class App extends Component {
         </p>
 
         <h3>Basic Example (uncontrolled)</h3>
-        <Example onChange={logChange("Basic")} defaults={{ value: 1 }} />
+        <Example onChange={logChange('Basic')} defaultValue={1} />
 
         <h3>Default Value (controlled)</h3>
-        <Example onChange={logChange("Default value")} value={2} />
+        <Example onChange={logChange('Default value')} defaultValue={2} />
 
-        <h3>Alternate Prop Names (controlled)</h3>
-        <ExampleWithMapping altHandler={logChange("Alt Props")} altProp={3} />
+        <h3>Alternate Prop Names (uncontrolled)</h3>
+        <ExampleWithMapping
+          altHandler={logChange('Alt Props')}
+          defaultAltProp={3}
+        />
+
+        <h3>Handling several props via a single map</h3>
+        <ExampleWithMultiProps
+          onClose={logChange('Closed')}
+          onOpen={logChange('Open')}
+        />
       </div>
     );
   }
 }
 
-ReactDOM.render(<App />, document.getElementById("app"));
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,7 @@
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
-import { Value, withValue } from 'react-value';
-import './index.css';
+import React, { Component } from "react";
+import ReactDOM from "react-dom";
+import { withValue } from "react-value";
+import "./index.css";
 
 const inc = i => (i || 0) + 1;
 
@@ -10,57 +10,66 @@ const logChange = name => value =>
 
 class Input extends Component {
   onClick = () => {
-    const { value } = this.props;
-    this.props.onChange(inc(value));
+    this.props.onChange(inc(this.props.value));
   };
   render() {
-    const { value } = this.props;
     return (
       <div>
-        <pre>{value || 0}</pre>
+        <pre>{this.props.value}</pre>
         <button onClick={this.onClick}>increment</button>
       </div>
     );
   }
 }
 
-const InputWithValue = withValue(Input);
+class InputWithMapping extends Component {
+  onClick = () => {
+    this.props.altHandler(inc(this.props.value));
+  };
+  render() {
+    return (
+      <div>
+        <pre>{this.props.altProp}</pre>
+        <button onClick={this.onClick}>increment</button>
+      </div>
+    );
+  }
+}
 
-const AltProps = ({ altValue, altOnChange, ...props }) => (
-  <Input value={altValue} onChange={altOnChange} {...props} />
-);
-
-const AltPropsWithValue = withValue(AltProps, {
-  valueProp: 'altValue',
-  onChangeProp: 'altOnChange',
+const Example = withValue(Input);
+const ExampleWithMapping = withValue(InputWithMapping, {
+  altProp: "altHandler"
 });
 
 class App extends Component {
   render() {
     return (
       <div>
-        <h3>Basic Example:</h3>
-        <Value
-          onChange={logChange('Basic')}
-          render={(value, onChange) => (
-            <Input value={value} onChange={onChange} />
-          )}
-        />
-        <h3>Default Value:</h3>
-        <Value
-          defaultValue={3}
-          onChange={logChange('With default')}
-          render={(value, onChange) => (
-            <Input value={value} onChange={onChange} />
-          )}
-        />
-        <h3>Higher Order Component:</h3>
-        <InputWithValue onChange={logChange('HOC')} defaultValue={5} />
-        <h3>Alternate Prop Names:</h3>
-        <AltPropsWithValue onChange={logChange('Alt Props')} defaultValue={8} />
+        <p>
+          Controlled examples provide a <code>value</code> prop and will not
+          change unless that prop is updated by the parent. You will see
+          controlled components log a value because the handler is still called.
+          This is so that you can update state inresponse to the change
+          manually.
+        </p>
+        <p>
+          Uncontrolled components do not provide a <code>value</code> and thus
+          will update the internal value for you automatically. You may provide
+          a <code>defaults</code> object prop that provides the initial, default
+          values for all values you're mapping.
+        </p>
+
+        <h3>Basic Example (uncontrolled)</h3>
+        <Example onChange={logChange("Basic")} defaults={{ value: 1 }} />
+
+        <h3>Default Value (controlled)</h3>
+        <Example onChange={logChange("Default value")} value={2} />
+
+        <h3>Alternate Prop Names (controlled)</h3>
+        <ExampleWithMapping altHandler={logChange("Alt Props")} altProp={3} />
       </div>
     );
   }
 }
 
-ReactDOM.render(<App />, document.getElementById('app'));
+ReactDOM.render(<App />, document.getElementById("app"));

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,20 +1,81 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import { Value, withValue } from '..';
+import React, { Fragment } from "react";
+import { mount } from "enzyme";
+import { withValue } from "..";
 
-function render(spy) {
-  return function(value, onChange) {
-    spy(value);
-    return <input onChange={onChange} value={value} />;
-  };
-}
+const Input = props => <input {...props} type="text" />;
+const InputWrapped = withValue(Input);
+const CustomWrapped = withValue(
+  props => (
+    <Fragment>
+      <input
+        className="input1"
+        onChange={e => props.onFunc1(e.target.value)}
+        value={props.value1}
+      />
+      <input
+        className="input2"
+        onChange={e => props.onFunc2(e.target.value)}
+        value={props.value2}
+      />
+    </Fragment>
+  ),
+  {
+    value1: "onFunc1",
+    value2: "onFunc2"
+  }
+);
 
-test('Value - should call onChange', () => {
+test("onChange", () => {
   const spy = jest.fn();
-  const val = shallow(<Value render={render(spy)} defaultValue={1} />);
+  const wrapper = mount(<InputWrapped onChange={spy} />);
+  const input = wrapper.find("input");
+
+  expect(spy).toHaveBeenCalledTimes(0);
+  expect(input.props()).toMatchObject({ value: undefined });
+  input.simulate("change", 1);
   expect(spy).toHaveBeenCalledTimes(1);
-  expect(spy).toHaveBeenCalledWith(1);
-  val.find('input').simulate('change', 2);
-  expect(spy).toHaveBeenCalledTimes(2);
-  expect(spy).toHaveBeenCalledWith(2);
+  expect(input.props()).toMatchObject({ value: undefined });
+});
+
+test("value (alone to test controlled / uncontrolled warnings)", () => {
+  const wrapper = mount(<InputWrapped value={1} />);
+  const input = wrapper.find("input");
+
+  expect(input.props()).toMatchObject({ value: 1 });
+});
+
+test("onChange + value", () => {
+  const spy = jest.fn();
+  const wrapper = mount(<InputWrapped onChange={spy} value={1} />);
+  const input = wrapper.find("input");
+
+  expect(spy).toHaveBeenCalledTimes(0);
+  expect(input.props()).toMatchObject({ value: 1 });
+  input.simulate("change", 1);
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(input.props()).toMatchObject({ value: 1 });
+});
+
+test("custom mapping", () => {
+  const spy1 = jest.fn();
+  const spy2 = jest.fn();
+  const wrapper = mount(
+    <CustomWrapped onFunc1={spy1} onFunc2={spy2} value1={1} value2={2} />
+  );
+  const input1 = wrapper.find(".input1");
+  const input2 = wrapper.find(".input2");
+
+  expect(spy1).toHaveBeenCalledTimes(0);
+  expect(spy2).toHaveBeenCalledTimes(0);
+  expect(input1.props().value).toBe(1);
+  expect(input2.props().value).toBe(2);
+
+  input1.simulate("change", 1);
+  input2.simulate("change", 2);
+
+  expect(spy1).toHaveBeenCalledTimes(1);
+  expect(spy2).toHaveBeenCalledTimes(1);
+
+  expect(spy1).toHaveBeenCalledWith("1");
+  expect(spy2).toHaveBeenCalledWith("2");
 });

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -31,10 +31,10 @@ test("onChange", () => {
   const input = wrapper.find("input");
 
   expect(spy).toHaveBeenCalledTimes(0);
-  expect(input.props()).toMatchObject({ value: undefined });
+  expect(input.props()).toMatchObject({ value: "" });
   input.simulate("change", 1);
   expect(spy).toHaveBeenCalledTimes(1);
-  expect(input.props()).toMatchObject({ value: undefined });
+  expect(input.props()).toMatchObject({ value: "" });
 });
 
 test("value (alone to test controlled / uncontrolled warnings)", () => {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -32,16 +32,11 @@ test("onChange", () => {
 
   expect(spy).toHaveBeenCalledTimes(0);
   expect(input.props()).toMatchObject({ value: "" });
+
   input.simulate("change", 1);
+
   expect(spy).toHaveBeenCalledTimes(1);
   expect(input.props()).toMatchObject({ value: "" });
-});
-
-test("value (alone to test controlled / uncontrolled warnings)", () => {
-  const wrapper = mount(<InputWrapped value={1} />);
-  const input = wrapper.find("input");
-
-  expect(input.props()).toMatchObject({ value: 1 });
 });
 
 test("onChange + value", () => {
@@ -51,7 +46,9 @@ test("onChange + value", () => {
 
   expect(spy).toHaveBeenCalledTimes(0);
   expect(input.props()).toMatchObject({ value: 1 });
+
   input.simulate("change", 1);
+
   expect(spy).toHaveBeenCalledTimes(1);
   expect(input.props()).toMatchObject({ value: 1 });
 });
@@ -78,4 +75,11 @@ test("custom mapping", () => {
 
   expect(spy1).toHaveBeenCalledWith("1");
   expect(spy2).toHaveBeenCalledWith("2");
+});
+
+test("defaults", () => {
+  const wrapper = mount(<InputWrapped defaults={{ value: "test" }} />);
+  const input = wrapper.find("input");
+
+  expect(input.props()).toMatchObject({ value: "test" });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,9 @@ export const withValue = (Comp: Class<Component<any>>, options: Options) => {
   options = { ...defaultOptions, ...options };
   return class extends Component<Props, State> {
     static defaultProps = {
-      defaults: {}
+      defaults: {
+        value: ""
+      }
     };
     state = {};
     render() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,87 +1,113 @@
 // @flow
 
-import React, { Component } from "react";
+import React, { Component } from 'react';
 
 type Comp = Component<Props, State>;
+
 type Ctor = Class<Component<any>>;
+
+type Event = {
+  target: {
+    value: string,
+  },
+};
 
 type Mapped = {
   funcs: { [string]: Function },
-  props: { [string]: any }
+  props: { [string]: any },
 };
 
 type Options = {
-  map: OptionsMap
-};
-
-type OptionsMap = {
-  [string]: string
+  [string]: {
+    defaultName: string,
+    defaultValue: string,
+    handlers: { [string]: Function },
+  },
 };
 
 type Props = {
   defaults: {
-    [string]: any
-  }
+    [string]: any,
+  },
 };
 
 type State = {
-  [string]: any
+  [string]: any,
 };
 
 const defaultOptions: Options = {
-  map: {
-    value: "onChange"
-  }
+  value: {
+    defaultName: 'defaultValue',
+    defaultValue: '',
+    handlers: {
+      onChange: (e: Event) => e.target.value,
+    },
+  },
 };
 
-function createFunc(comp, propName, funcName) {
+function createFunc(comp, propName, handlerName, handlerFunc) {
   return function(value: any) {
-    const func = comp.props[funcName];
+    const func = comp.props[handlerName];
+    const handledValue = handlerFunc(value);
+
     if (!(propName in comp.props)) {
-      comp.setState({ [propName]: value });
+      comp.setState({ [propName]: handledValue });
     }
-    if (typeof func === "function") {
+
+    if (typeof func === 'function') {
       func(value);
     }
   };
 }
 
-function createFuncsAndProps(comp: Comp, map: OptionsMap): Mapped {
-  return Object.keys(map).reduce(
+function createFuncsAndProps(comp: Comp, opts: Options): Mapped {
+  return Object.keys(opts).reduce(
     (result, propName) => {
-      const funcName = map[propName];
-      result.funcs[funcName] = createFunc(comp, propName, funcName);
+      const { defaultName, defaultValue, handlers } = opts[propName];
+
+      Object.keys(handlers).forEach(handlerName => {
+        result.funcs[handlerName] = createFunc(
+          comp,
+          propName,
+          handlerName,
+          handlers[handlerName]
+        );
+      });
+
       Object.defineProperty(result.props, propName, {
         enumerable: true,
         get() {
           const { props, state } = comp;
           return propName in props
             ? props[propName]
-            : propName in state ? state[propName] : props.defaults[propName];
-        }
+            : propName in state
+              ? state[propName]
+              : defaultName in props ? props[defaultName] : defaultValue;
+        },
       });
+
       return result;
     },
     {
       funcs: {},
-      props: {}
+      props: {},
     }
   );
 }
 
-export const withValue = (Comp: Ctor, options: Options) => {
-  options = { ...defaultOptions, ...options };
+export const withValue = (Comp: Ctor, opts: Options) => {
+  opts = { ...defaultOptions, ...opts };
   return class extends Component<Props, State> {
     mapped: Mapped;
     static defaultProps = {
       defaults: {
-        value: ""
-      }
+        value: '',
+      },
     };
     state = {};
     constructor(props: Props) {
       super(props);
-      this.mapped = createFuncsAndProps(this, options.map);
+      this.mapped = createFuncsAndProps(this, opts);
     }
     render() {
       const { funcs, props } = this.mapped;


### PR DESCRIPTION
- Remove `Value` component (unnecessary?).
- Change `defaultValue` to just `value`. This allows `value` to be passed through, and gets around any warnings about switching between controlled and uncontrolled modes.
- Apply defaults as a single prop called `defaults` that is an object containing default values for each mapped prop.
- Update HOC to accept a mapping of `propName` to `funcName` and default to old values.
- Add tests.

There's some Prettier happening in here due to their defaults. We should add a prettier config and fix this up later.